### PR TITLE
Update 6 for 6 to cover 2 months rather than 7 weeks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ application.conf
 target
 .idea
 *.csv
+*.txt

--- a/src/main/scala/com/gu/zuora6for6modifier/Config.scala
+++ b/src/main/scala/com/gu/zuora6for6modifier/Config.scala
@@ -9,9 +9,5 @@ object Config {
     lazy val stage: String = conf.getString("zuora.stage")
     lazy val client_id: String = conf.getString("zuora.client_id")
     lazy val client_secret: String = conf.getString("zuora.client_secret")
-    lazy val productPlanId6For6: Map[String, String] = Map(
-      "GW Oct 18 - Six for Six - Domestic" -> conf.getString("zuora.productPlanId6For6.Domestic"),
-      "GW Oct 18 - Six for Six - ROW" -> conf.getString("zuora.productPlanId6For6.ROW")
-    )
   }
 }

--- a/src/main/scala/com/gu/zuora6for6modifier/SubData.scala
+++ b/src/main/scala/com/gu/zuora6for6modifier/SubData.scala
@@ -3,6 +3,7 @@ package com.gu.zuora6for6modifier
 case class SubData(
     subName: String,
     productPlanId6For6: String,
+    productChargeId6For6: String,
     productPlanIdMain: String,
     start6For6Date: String,
     startMainDate: String,

--- a/src/main/scala/com/gu/zuora6for6modifier/Subscription.scala
+++ b/src/main/scala/com/gu/zuora6for6modifier/Subscription.scala
@@ -41,12 +41,10 @@ object Subscription {
         .find(_.ratePlanName.startsWith(productRatePlanNamePrefixMain))
         .toRight("Can't find main plan")
       chargeMain <- planMain.ratePlanCharges.headOption.toRight("Can't find main charge")
-      productPlanId6For6 <- Config.Zuora.productPlanId6For6
-        .get(plan6For6.ratePlanName)
-        .toRight("Can't find corresponding 6 for 7 plan")
     } yield SubData(
       subName,
-      productPlanId6For6,
+      productPlanId6For6 = plan6For6.productRatePlanId,
+      productChargeId6For6 = charge6For6.productRatePlanChargeId,
       productPlanIdMain = planMain.productRatePlanId,
       start6For6Date = charge6For6.effectiveStartDate,
       startMainDate = plusWeek(chargeMain.effectiveStartDate),

--- a/src/main/scala/com/gu/zuora6for6modifier/Zuora.scala
+++ b/src/main/scala/com/gu/zuora6for6modifier/Zuora.scala
@@ -78,7 +78,14 @@ trait ZuoraLive extends Zuora {
              |  "add": [
              |    {
              |      "contractEffectiveDate": "${subData.start6For6Date}",
-             |      "productRatePlanId": "${subData.productPlanId6For6}"
+             |      "productRatePlanId": "${subData.productPlanId6For6}",
+             |      "chargeOverrides": [
+             |        {
+             |          "productRatePlanChargeId": "${subData.productChargeId6For6}",
+             |          "billingPeriod": "Specific_Months",
+             |          "specificBillingPeriod": 2
+             |        }
+             |      ]
              |    },
              |    {
              |      "contractEffectiveDate": "${subData.startMainDate}",
@@ -92,7 +99,7 @@ trait ZuoraLive extends Zuora {
              |    },
              |    {
              |      "ratePlanId": "${subData.planIdMain}",
-             |      "contractEffectiveDate": "${subData.startMainDate}"
+             |      "contractEffectiveDate": "${subData.start6For6Date}"
              |    }
              |  ]
              |}
@@ -121,9 +128,8 @@ trait ZuoraLive extends Zuora {
 object ZuoraHostSelector {
   val host: String =
     Config.Zuora.stage match {
-      case "DEV" | "dev"   => "https://rest.apisandbox.zuora.com"
-      case "PROD" | "prod" => "https://rest.zuora.com"
-      case _               => "https://rest.apisandbox.zuora.com"
+      case "DEV" | "UAT" => "https://rest.apisandbox.zuora.com"
+      case "PROD"        => "https://rest.zuora.com"
     }
 }
 


### PR DESCRIPTION
because there appears to be a bug in Zuora, which won't allow you to update a rate plan charge with a specific_weeks value.