### PR TITLE
Add queries to find relevant subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ In the Prod stage there is a dedicated user configured, called `Christmas 6 for 
 Use your own credentials for the other stages.
 
 ## Queries
-The queries used to find relevant subscriptions are [here](queries).
+The queries used to find relevant subscriptions in the BigQuery data lake are [here](queries).

--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ zuora {
 ```
 In the Prod stage there is a dedicated user configured, called `Christmas 6 for 6 extender`.
 Use your own credentials for the other stages.
+
+## Queries
+The queries used to find relevant subscriptions are [here](queries).

--- a/queries/6For6ToExtend.json
+++ b/queries/6For6ToExtend.json
@@ -1,0 +1,9 @@
+{
+  "name": "6For6ToExtend",
+  "queries": [
+    {
+      "type": "zoqlexport",
+      "query": "select Subscription.Name from RatePlanCharge where Subscription.Status = 'Active' and EffectiveStartDate < '2020-12-25' and EffectiveEndDate > '2020-12-25' and Name like 'GW%6%'"
+    }
+  ]
+}

--- a/queries/6For6ToExtend.sql
+++ b/queries/6For6ToExtend.sql
@@ -1,0 +1,10 @@
+-- Find GW subscriptions whose introductory period includes Christmas week so that they can be extended by a week.
+select c.subscription_id, c.name, s.term_start_date, c.effective_start_date, c.effective_end_date
+from datalake.zuora_rateplancharge c,
+     datalake.zuora_subscription s
+where c.subscription_id = s.id
+  and s.status = 'Active'
+  and c.product_name like 'Guardian Weekly%'
+  and (c.name like '%6%' or lower(c.name) like '%six%')
+  and c.effective_start_date < '2020-12-25'
+  and c.effective_end_date > '2020-12-25'

--- a/queries/6For6ToPushBack.json
+++ b/queries/6For6ToPushBack.json
@@ -1,0 +1,9 @@
+{
+  "name": "6For6ToPushBack",
+  "queries": [
+    {
+      "type": "zoqlexport",
+      "query": "select Subscription.Name from RatePlanCharge where Subscription.Status = 'Active' and EffectiveStartDate = '2020-12-25' and Name like 'GW%6%'"
+    }
+  ]
+}

--- a/queries/6For6ToPushBack.sql
+++ b/queries/6For6ToPushBack.sql
@@ -1,0 +1,9 @@
+-- Find GW subscriptions whose introductory period begins in Christmas week so that they can be pushed back by a week.
+select c.subscription_id, c.name, s.term_start_date
+from datalake.zuora_rateplancharge c,
+     datalake.zuora_subscription s
+where c.subscription_id = s.id
+  and s.status = 'Active'
+  and c.product_name like 'Guardian Weekly%'
+  and (c.name like '%6%' or lower(c.name) like '%six%')
+  and c.effective_start_date = '2020-12-25'

--- a/queries/FirstBillAfter6For6ToPushBack.json
+++ b/queries/FirstBillAfter6For6ToPushBack.json
@@ -1,0 +1,9 @@
+{
+  "name": "FirstBillAfter6For6ToPushBack",
+  "queries": [
+    {
+      "type": "zoqlexport",
+      "query": "select Subscription.Name from RatePlanCharge where Product.Name like 'Guardian Weekly%' and Subscription.Status = 'Active' and EffectiveStartDate = '2020-12-25' and not Name like 'GW%6%'"
+    }
+  ]
+}

--- a/queries/FirstBillAfter6For6ToPushBack.sql
+++ b/queries/FirstBillAfter6For6ToPushBack.sql
@@ -1,0 +1,11 @@
+-- Find GW subscriptions whose first billing period after the introductory period begins in Christmas week
+-- so that they can be pushed back by a week.
+select c.subscription_id, c.name, s.term_start_date
+from datalake.zuora_rateplancharge c,
+     datalake.zuora_subscription s
+where c.subscription_id = s.id
+  and c.product_name like 'Guardian Weekly%'
+  and c.name not like '%6%'
+  and lower(c.name) not like '%six%'
+  and s.status = 'Active'
+  and effective_start_date = '2020-12-25'


### PR DESCRIPTION
For future reference, this adds the BQ data lake queries for the 3 groups of subs to be modified.
